### PR TITLE
Refactor inferred stability into base class and config file

### DIFF
--- a/opentrickler_config.ini
+++ b/opentrickler_config.ini
@@ -17,6 +17,8 @@ baudrate = 19200
 timeout = 0.1
 # Open trickler version for legacy status mapping. Don't change unless you know what you are doing.
 status_map_version = 0
+# For scales that don't provide a stability flag, a number of consecutive readings to infer stability.
+stable_reading_length = 5
 
 
 [motors]


### PR DESCRIPTION
# Changes

- Move the number of scale readings from the class into the config file
- Move the function and class property that are used to infer scale stability into the base class so they can optionally be used elsewhere.